### PR TITLE
Fix for Inverted Gyros mainly NavX

### DIFF
--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -43,7 +43,6 @@ public class DriveSubsystem extends SubsystemBase {
 
   // The gyro sensor
   private final ADIS16470_IMU m_gyro = new ADIS16470_IMU();
-  private double gyroInversion = 1;
 
   // Slew rate filter variables for controlling lateral acceleration
   private double m_currentRotation = 0.0;


### PR DESCRIPTION
The invert gyro variable does not work for actually inverting the gyros. This change addresses #12 